### PR TITLE
Add cpr howfig to enable Work Queue coproceses

### DIFF
--- a/scripts/runapp-g3wfpipe
+++ b/scripts/runapp-g3wfpipe
@@ -38,6 +38,7 @@ if [[ -z $1 || $1 = -h ]]; then
   echo "  cfsXXX: Append -cfsXXX to the user name for data output."
   echo HFG = HF1-HF2-... where HFi is any of
   echo "  exec:XX where XX = wq (XX is GB memory) or tp (XX is process count)"
+  echo "  cpr: Use coprocesses with WQ. Ignored if not WQ"
   echo "  rebuild: Rebuild the SW cache (cvmfs only)."
   echo "  cvmfs: Code taken from default env using LSST cvmfs"
   echo "  cvmfs:BBB: Code taken from env option BBB using LSST cvmfs code"
@@ -273,6 +274,7 @@ PGROUPS=
 PMONDT=${CON_PMONDT:-3}  
 PFSOPT=${CON_PFSOPT:-0}
 STRACE=$CON_STRACE
+COPROCESS=
 REBUILD=false
 for OPT in ${HOPTS[@]}; do
   info_echo Processing howfig opt $OPT
@@ -288,6 +290,8 @@ for OPT in ${HOPTS[@]}; do
     EXEC=$OPT
   elif [ ${OPT:0:5} = pmon: ]; then
     PMONDT=${OPT:5}
+  elif [ ${OPT} = cpr ]; then
+    COPROCESS=True
   elif [ ${OPT:0:5} = tmax: ]; then
     IFS=':' read -ra TMAXS <<< "${OPT:5}"
     NTMAX=${#TMAXS}
@@ -450,6 +454,9 @@ PIPEVAL=
     echo "  monitoring: false" >>config.yaml
   else
     echo "  monitoring_interval: $PMONDT" >>config.yaml
+  fi
+  if [ -n "$COPROCESS" ]; then
+    echo "  coprocess: $COPROCESS" >>config.yaml
   fi
 
   #  monitoring: parsl.monitoring.monitoring.MonitoringHub(


### PR DESCRIPTION
This needs gen3_workflow >= dfb717bc665985018ad4b3135272abd60023c362 to pass the configuration through gen3_workflow to Parsl.